### PR TITLE
Airtable replies with "Unknown column: id" when we try to call update…

### DIFF
--- a/lib/airtable/record.rb
+++ b/lib/airtable/record.rb
@@ -34,7 +34,10 @@ module Airtable
     end
 
     # Hash with keys based on airtable original column names
-    def fields; Hash[@columns_map.map { |k| [ k, @attrs[to_key(k)] ] }]; end
+    def fields; HashWithIndifferentAccess.new(Hash[@columns_map.map { |k| [ k, @attrs[to_key(k)] ] }]); end
+
+    # Airtable will complain if we pass an 'id' as part of the request body.
+    def fields_for_update; fields.except(:id); end
 
     def method_missing(name, *args, &blk)
       # Accessor for attributes

--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -49,7 +49,7 @@ module Airtable
     # Replaces record in airtable based on id
     def update(record)
       result = self.class.put(worksheet_url + "/" + record.id,
-        :body => { "fields" => record.fields }.to_json,
+        :body => { "fields" => record.fields_for_update }.to_json,
         :headers => { "Content-type" => "application/json" }).parsed_response
       if result.present? && result["id"].present?
         record.override_attributes!(result_attributes(result))

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -41,6 +41,7 @@ describe Airtable do
         table.update(record)
         assert_equal "12345", record["id"]
         assert_equal "bar", record["foo"]
-      end
+    end
+
   end # describe Airtable
 end # Airtable

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+describe Airtable do
+  describe Airtable::Record do
+    it "should not return id in fields_for_update" do
+      record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
+      record.fields_for_update.wont_include(:id)
+    end
+  end # describe Record
+end # Airtable


### PR DESCRIPTION
…. When updating, one should not send the `id` column in the request body. Adding new method `fields_for_update` and a small test.

Also changing the `fields` method to return a `HashWithIndifferentAccess` instead of a hash. In tests, we're initializing records via a hash with symbol-based keys, whereas actual Airtable initialize from string-based keys. For simplicity, it makes sense to just use `HashWithIndifferentAccess` across the board.