### PR TITLE
record: include new fields when updating records

### DIFF
--- a/lib/airtable/record.rb
+++ b/lib/airtable/record.rb
@@ -28,13 +28,14 @@ module Airtable
 
     # Removes old and add new attributes for the record
     def override_attributes!(attrs={})
-      @columns_map = attrs.keys
       @attrs = HashWithIndifferentAccess.new(Hash[attrs.map { |k, v| [ to_key(k), v ] }])
       @attrs.map { |k, v| define_accessor(k) }
     end
 
     # Hash with keys based on airtable original column names
-    def fields; HashWithIndifferentAccess.new(Hash[@columns_map.map { |k| [ k, @attrs[to_key(k)] ] }]); end
+    def fields
+      HashWithIndifferentAccess.new(Hash[@attrs.keys.map { |k| [ k, @attrs[to_key(k)] ] }])
+    end
 
     # Airtable will complain if we pass an 'id' as part of the request body.
     def fields_for_update; fields.except(:id); end
@@ -70,5 +71,4 @@ module Airtable
     end
 
   end # Record
-
 end # Airtable

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -6,5 +6,11 @@ describe Airtable do
       record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
       record.fields_for_update.wont_include(:id)
     end
+
+    it "returns new columns in fields_for_update" do
+      record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
+      record[:website] = "http://sarahjaine.com"
+      record.fields_for_update.must_include(:website)
+    end
   end # describe Record
 end # Airtable


### PR DESCRIPTION
The Airtable API only gives back fields that aren't `nil`, but if you attempt to change one of those `nil` fields from the gem, `#fields_for_update` won't return it and it won't be posted to the API. Instead of caching `@column_keys`, we generate it anew on every request.