### PR TITLE
record: use original column names

### DIFF
--- a/lib/airtable/record.rb
+++ b/lib/airtable/record.rb
@@ -15,6 +15,7 @@ module Airtable
 
     # Set the given attribute to value
     def []=(name, value)
+      @column_keys << name
       @attrs[to_key(name)] = value
       define_accessor(name) unless respond_to?(name)
     end
@@ -28,13 +29,14 @@ module Airtable
 
     # Removes old and add new attributes for the record
     def override_attributes!(attrs={})
+      @column_keys = attrs.keys
       @attrs = HashWithIndifferentAccess.new(Hash[attrs.map { |k, v| [ to_key(k), v ] }])
       @attrs.map { |k, v| define_accessor(k) }
     end
 
     # Hash with keys based on airtable original column names
     def fields
-      HashWithIndifferentAccess.new(Hash[@attrs.keys.map { |k| [ k, @attrs[to_key(k)] ] }])
+      HashWithIndifferentAccess.new(Hash[@column_keys.map { |k| [ k, @attrs[to_key(k)] ] }])
     end
 
     # Airtable will complain if we pass an 'id' as part of the request body.

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -12,5 +12,10 @@ describe Airtable do
       record[:website] = "http://sarahjaine.com"
       record.fields_for_update.must_include(:website)
     end
+
+    it "returns fields_for_update in original capitalization" do
+      record = Airtable::Record.new("Name" => "Sarah Jaine")
+      record.fields_for_update.must_include("Name")
+    end
   end # describe Record
 end # Airtable


### PR DESCRIPTION
I'm dooomb, the reason why `@column_keys` was around was because they're all normalized in `@attrs` for easier access and we need the original ones to post back to Airtable, otherwise e.g. `Name of User` gets normalized to `name_of_user` and then posted back to Airtable as `name_of_user`, instead of as `Name of User`. 0.0.7 with my previous patch doesn't work at all.

Sorry, should've tested better. The Record class needs a bit of an overhaul, but I wanted to just unblock myself for now.