### PR TITLE
Update `Deleting Records` Readme part

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Records can be updated using the `update` method on a table:
 
 ### Deleting Records
 
-Records can be destroyed using the `destroy` method on a table:
+Records can be destroyed using the `destroy` method on a table (by passing the id as argument):
 
 ```ruby
-@table.destroy(record)
+@table.destroy("rec02sKGVIzU65eV2")
 ```
 
 ## Contributing


### PR DESCRIPTION
According to these lines of code:
https://github.com/Airtable/airtable-ruby/blob/041a8baf8ae59279630912d6ff329faa64398cb2/lib/airtable/table.rb#L96-L99

The destroy methods takes an id, and not a record.