### PR TITLE
Remove note about library status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 Easily connect to [airtable](https://airtable.com) data using ruby with access to all of the airtable features.
 
-# Note on library status
-
-We are currently transitioning this gem to be supported by
-Airtable. We will maintain it moving forward, but until we fully
-support it, it will stay in the status of "community libraries". At
-that time we will remove this notice and add a "ruby" section to the
-API docs.
-
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
Because Airtable intends to deprecate this module, we should remove this notice from the readme.