### PR TITLE
Make records() defer to select()

### DIFF
--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -22,10 +22,8 @@ module Airtable
     # Options: limit = 100, offset = "as345g", sort = ["Name", "asc"]
     # records(:sort => ["Name", :desc], :limit => 50, :offset => "as345g")
     def records(options={})
-      options["sortField"], options["sortDirection"] = options.delete(:sort) if options[:sort]
-      results = self.class.get(worksheet_url, query: options).parsed_response
-      check_and_raise_error(results)
-      RecordSet.new(results)
+      # previous was just a limited version of select()
+      select(options)
     end
 
     # Query for records using a string formula

--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -1,16 +1,13 @@
 module Airtable
 
   class Table < Resource
-    # Maximum results per request
-    LIMIT_MAX = 100
-
     # Fetch all records iterating through offsets until retrieving the entire collection
     # all(:sort => ["Name", :desc])
     def all(options={})
       offset = nil
       results = []
       begin
-        options.merge!(:limit => LIMIT_MAX, :offset => offset)
+        options.merge!(:offset => offset)
         response = records(options)
         results += response.records
         offset = response.offset


### PR DESCRIPTION
It seems that `records` is just a limited version of `select`. This means for example that we can't pass a formula to `all`, which means we have to manually iterate on queries that have a formula.

This simply makes `records` defer to `select`. All existing code will work exactly as it does now, but we have the option to control `all` with more flexibility.